### PR TITLE
Bug fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ app.get('/:owner/:repo.svg', (req, res) => {
     const options = {
         url: `${api}repos/${req.params.owner}/${req.params.repo}/commits?${token}`,
         headers: {
-            'User-Agent': process.env.USERAGENT
+            'User-Agent': `${process.env.USERAGENT}`
         }
     };
 


### PR DESCRIPTION
I think the `process.env.USERAGENT` needs to be within a template literal, when it is a property of a Javascript/JSON object.  

Otherwise it become undefined, and the server doesn't work (on my machine).